### PR TITLE
Don't copy the response Transfer-Encoding header

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,8 @@ module.exports = function proxy(host, options) {
         if (!res.headersSent) { // if header is not set yet
           res.status(rsp.statusCode);
           for (var p in rsp.headers) {
+            if (p == 'transfer-encoding')
+              continue;
             res.set(p, rsp.headers[p]);
           }
         }


### PR DESCRIPTION
This stops `express-http-proxy` from preserving the response's
`Transfer-Encoding` header.

Without this, when `express-http-proxy` tries to proxy a response with
`Transfer-Encoding: chunked` set, the response is de-chunked by waiting
on all the chunks and joining them, indeed, a Content-Lenght header is
computed and set if intercepting. But trying to send a response with
both `Content-Length` and `Transfer-Encodign: chunked` fails with a
`Parse error`, because it doesn't make sense.

Thus, we explicitly skip copying over `Transfer-Encoding`.
